### PR TITLE
Add MicroK8sClusterUpgradeEvent class Update microk8scluster.py

### DIFF
--- a/src/microk8scluster.py
+++ b/src/microk8scluster.py
@@ -120,6 +120,14 @@ class MicroK8sClusterEvents(ObjectEvents):
     node_added = EventSource(MicroK8sClusterNodeAddedEvent)
     other_node_removed = EventSource(MicroK8sClusterOtherNodeRemovedEvent)
     this_node_removed = EventSource(MicroK8sClusterThisNodeRemovedEvent)
+    
+class MicroK8sClusterUpgradeEvent(MicroK8sClusterEvent):
+    """An event triggered when a MicroK8s cluster upgrade is requested"""
+
+    def __init__(self, upgrade_version):
+        super().__init__()
+        self.upgrade_version = upgrade_version
+
 
 
 class MicroK8sCluster(Object):


### PR DESCRIPTION
This commit adds a new class, MicroK8sClusterUpgradeEvent, to the MicroK8sCluster. This class represents an event that can be triggered when an upgrade to the MicroK8s cluster is requested. The class extends the MicroK8sClusterEvent base class and includes an upgrade_version parameter that specifies the version to which the upgrade is being requested. The upgrade_version parameter is set in the init method of the class.

This new class can be used to trigger an upgrade event and respond to it accordingly. The handle_event method of the MicroK8sCluster class can check if an event is an instance of MicroK8sClusterUpgradeEvent and, if so, call the upgrade method with the specified version. The upgrade method would then perform the upgrade logic for the MicroK8s cluster.